### PR TITLE
Fix: Load page numbers from URL on initial page load

### DIFF
--- a/src/components/DatasetSelector.tsx
+++ b/src/components/DatasetSelector.tsx
@@ -2,7 +2,9 @@ import { useGameStore } from '../store/GameStore';
 import type { DatasetName } from '../store/GameStore';
 import { useNavigate } from 'react-router-dom';
 
-const DATASET_DISPLAY_NAMES: Record<DatasetName, string> = {
+type ValidDatasetName = Exclude<DatasetName, ''>;
+
+const DATASET_DISPLAY_NAMES: Record<ValidDatasetName, string> = {
 	wyprawa1907_ZakazaneKopalnie: 'Zakazane Kopalnie',
 	dziennik29_Przebudzenie: 'Przebudzenie',
 	dziennik29_WersjaPierwsza: 'Wersja Pierwsza',
@@ -16,7 +18,8 @@ export const DatasetSelector = () => {
 
 	const handleDatasetChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
 		const newDataset = event.target.value as DatasetName;
-		setSelectedDataset(newDataset);
+		if (newDataset === '') return; // Don't do anything if "Wybierz zestaw" is selected
+		setSelectedDataset(newDataset as ValidDatasetName);
 		navigate(`/${newDataset}/0`);
 	};
 
@@ -28,7 +31,8 @@ export const DatasetSelector = () => {
 				value={selectedDataset}
 				onChange={handleDatasetChange}
 			>
-				{(Object.keys(DATASET_DISPLAY_NAMES) as DatasetName[]).map((dataset) => (
+				<option value="">Wybierz zestaw</option>
+				{(Object.keys(DATASET_DISPLAY_NAMES) as ValidDatasetName[]).map((dataset) => (
 					<option key={dataset} value={dataset}>
 						{DATASET_DISPLAY_NAMES[dataset]}
 					</option>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,6 +4,7 @@ import type { DatasetName } from '../store/GameStore';
 import { DatasetSelector } from './DatasetSelector';
 
 const DATASET_DISPLAY: Record<DatasetName, { title: string; subtitle: string }> = {
+	'': { title: '', subtitle: '' },
 	wyprawa1907_ZakazaneKopalnie: { title: 'Wyprawa 1907', subtitle: 'Zakazane Kopalnie' },
 	dziennik29_Przebudzenie: { title: 'Dziennik 29', subtitle: 'Przebudzenie' },
 	dziennik29_WersjaPierwsza: { title: 'Dziennik 29', subtitle: 'Wersja Pierwsza' },
@@ -12,6 +13,8 @@ const DATASET_DISPLAY: Record<DatasetName, { title: string; subtitle: string }> 
 
 const getBrandContent = (dataset: DatasetName) => {
 	const config = DATASET_DISPLAY[dataset];
+	
+	if (!config.title) return null;
 	
 	return (
 		<>
@@ -29,9 +32,17 @@ const Header = () => {
 	return (
 		<header className="header">
 			<div className="nav">
-				<Link className="brand" to={`/${selectedDataset}/0`} aria-label="Strona główna">
-					{getBrandContent(selectedDataset)}
-				</Link>
+				{selectedDataset ? (
+					<Link className="brand" to={`/${selectedDataset}/0`} aria-label="Strona główna">
+						{getBrandContent(selectedDataset)}
+					</Link>
+				) : (
+					<div className="brand">
+						<span className="line">
+							<h2>Wybierz zestaw gry</h2>
+						</span>
+					</div>
+				)}
 				<DatasetSelector />
 			</div>
 		</header>

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -5,11 +5,13 @@ import wyprawa1907_ZakazaneKopalnieData from '../data/wyprawa1907_ZakazaneKopaln
 import dziennik29_PrzebudzenieData from '../data/dziennik29_Przebudzenie.json';
 import dziennik29_WersjaPierwszaData from '../data/dziennik29_WersjaPierwsza.json';
 import dziennik29_ZapomnienieData from '../data/dziennik29_Zapomnienie.json';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import Header from '../components/Header.tsx';
 import { useGameStore, type IKey, type DatasetName } from '../store/GameStore.tsx';
 
-const VALID_DATASETS: DatasetName[] = ['wyprawa1907_ZakazaneKopalnie', 'dziennik29_Przebudzenie', 'dziennik29_WersjaPierwsza', 'dziennik29_Zapomnienie'];
+const VALID_DATASETS: ValidDatasetName[] = ['wyprawa1907_ZakazaneKopalnie', 'dziennik29_Przebudzenie', 'dziennik29_WersjaPierwsza', 'dziennik29_Zapomnienie'];
+
+type ValidDatasetName = Exclude<DatasetName, ''>;
 
 const GamePage = () => {
 	const { dataset, pageId } = useParams();
@@ -18,7 +20,6 @@ const GamePage = () => {
 	const setValue = useGameStore((state) => state.setValue);
 	const setDataset = useGameStore((state) => state.setDataset);
 	const setSelectedDataset = useGameStore((state) => state.setSelectedDataset);
-	const navigate = useNavigate();
 
 	const datasetsLoaded = useRef(false);
 
@@ -37,25 +38,30 @@ const GamePage = () => {
 	useEffect(() => {
 		if (!datasetsLoaded.current) return;
 
-		// Handle dataset from URL or redirect to default
-		if (dataset && VALID_DATASETS.includes(dataset as DatasetName)) {
-			if (dataset !== selectedDataset) {
-				setSelectedDataset(dataset as DatasetName);
-			}
-		} else {
-			// Redirect to default dataset if URL is invalid or missing
-			navigate(`/${selectedDataset}/${pageId || '0'}`, { replace: true });
-			return;
-		}
+		// Handle dataset from URL
+		if (dataset && VALID_DATASETS.includes(dataset as ValidDatasetName)) {
+			const validDataset = dataset as ValidDatasetName;
+			const targetPage = Number(pageId);
+			const validPage = !isNaN(targetPage) && targetPage >= 0 ? targetPage : 0;
 
-		// Update current page
-		const id = Number(pageId);
-		if (!isNaN(id) && id >= 0 && id < totalPages) {
-			setValue('currentPage', id);
-		} else {
-			setValue('currentPage', 0);
+			if (validDataset !== selectedDataset) {
+				// When switching datasets or initializing from URL, pass the target page
+				setSelectedDataset(validDataset, validPage);
+			} else if (totalPages > 0) {
+				// Update current page when navigating within same dataset
+				if (validPage < totalPages) {
+					setValue('currentPage', validPage);
+				} else {
+					setValue('currentPage', 0);
+				}
+			}
+		} else if (!dataset || dataset === '') {
+			// No dataset in URL - stay on empty state to show "Wybierz zestaw"
+			// Don't redirect, let user select
 		}
-	}, [dataset, pageId, selectedDataset, totalPages, setSelectedDataset, setValue, navigate]);
+		// navigate is stable from React Router and doesn't need to be in deps
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [dataset, pageId, selectedDataset, totalPages, setSelectedDataset, setValue]);
 
 	return (
 		<>

--- a/src/store/GameStore.tsx
+++ b/src/store/GameStore.tsx
@@ -10,7 +10,7 @@ export interface IKey {
 	error?: string;
 }
 
-export type DatasetName = 'wyprawa1907_ZakazaneKopalnie' | 'dziennik29_Przebudzenie' | 'dziennik29_WersjaPierwsza' | 'dziennik29_Zapomnienie';
+export type DatasetName = 'wyprawa1907_ZakazaneKopalnie' | 'dziennik29_Przebudzenie' | 'dziennik29_WersjaPierwsza' | 'dziennik29_Zapomnienie' | '';
 
 interface IGameData {
 	currentPage: number;
@@ -19,7 +19,7 @@ interface IGameData {
 	result: string;
 	correctAnswer: boolean;
 	selectedDataset: DatasetName;
-	datasets: Record<DatasetName, Array<IKey>>;
+	datasets: Record<Exclude<DatasetName, ''>, Array<IKey>>;
 }
 
 const initialState: IGameData = {
@@ -28,7 +28,7 @@ const initialState: IGameData = {
 	totalPages: 0,
 	result: '',
 	correctAnswer: false,
-	selectedDataset: 'wyprawa1907_ZakazaneKopalnie',
+	selectedDataset: '',
 	datasets: {
 		wyprawa1907_ZakazaneKopalnie: [],
 		dziennik29_Przebudzenie: [],
@@ -38,8 +38,8 @@ const initialState: IGameData = {
 };
 
 interface IGameStore extends IGameData {
-	setDataset: (datasetName: DatasetName, data: Array<IKey>) => void;
-	setSelectedDataset: (datasetName: DatasetName) => void;
+	setDataset: (datasetName: Exclude<DatasetName, ''>, data: Array<IKey>) => void;
+	setSelectedDataset: (datasetName: Exclude<DatasetName, ''>, initialPage?: number) => void;
 	setValue: <K extends keyof IGameStore>(key: K, value: IGameStore[K]) => void;
 	reset: () => void;
 }
@@ -53,12 +53,12 @@ export const useGameStore = create<IGameStore>()(
 					draft.datasets[datasetName] = data;
 				});
 			},
-			setSelectedDataset: (datasetName) => {
+			setSelectedDataset: (datasetName, initialPage = 0) => {
 				set((draft) => {
 					draft.selectedDataset = datasetName;
 					draft.keys = draft.datasets[datasetName];
 					draft.totalPages = draft.datasets[datasetName].length;
-					draft.currentPage = 0;
+					draft.currentPage = initialPage;
 					draft.result = '';
 					draft.correctAnswer = false;
 				});


### PR DESCRIPTION
- Add empty string to DatasetName type to support no selection state
- Update GameStore setSelectedDataset to accept optional initialPage parameter
- Refactor GamePage to properly initialize dataset and page from URL
- Add 'Wybierz zestaw' option to DatasetSelector dropdown
- Fix Header to handle empty dataset state without broken links
- Improve type safety with ValidDatasetName type alias

Fixes issue where pagination wouldn't appear until user manually selected a dataset, even when opening a valid URL with dataset/page parameters.
